### PR TITLE
installScript及uninstallScript无法调用问题

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -228,8 +228,8 @@ class Plugin
 
         $frontDirectory = self::getConfig('front_directory', BASE_PATH . '/web');
 
-        if (! empty($info['installScript']) && class_exists($info['installScript'])) {
-            $installScript = ApplicationContext::getContainer()->make($info['installScript']);
+        if (! empty($info['composer']['installScript']) && class_exists($info['composer']['installScript'])) {
+            $installScript = ApplicationContext::getContainer()->make($info['composer']['installScript']);
             $installScript();
         }
 
@@ -303,8 +303,8 @@ class Plugin
                 'No installation behavior was detected for this plugin, and uninstallation could not be performed'
             );
         }
-        if (! empty($info['uninstallScript']) && class_exists($info['uninstallScript'])) {
-            $uninstallScript = ApplicationContext::getContainer()->make($info['uninstallScript']);
+        if (! empty($info['composer']['uninstallScript']) && class_exists($info['composer']['uninstallScript'])) {
+            $uninstallScript = ApplicationContext::getContainer()->make($info['composer']['uninstallScript']);
             $uninstallScript();
         }
         if (! empty($info['composer']['require'])) {


### PR DESCRIPTION
创建插件命令时，是将InstallScript&UninstallScript放在composer下的，但是调用的时候调用的根结点的
$output->composer = [
      'require' => [],
      'psr-4' => [
          $namespace . '\\' => 'src',
      ],
      'installScript' => $namespace . '\\InstallScript',
      'uninstallScript' => $namespace . '\\UninstallScript',
      'config' => $namespace . '\\ConfigProvider',
  ];